### PR TITLE
Revert fullscreen browser.  It still doesn't work right on ios.

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,24 +53,6 @@
 
 
 
-  <script>
-    // iOS disables pull to refresh on standalone
-    // so this attempts to add it back
-    function p2() {
-      if (navigator.userAgent.match(/(iPhone|iPod|iPad)/i) && window.navigator.standalone) {
-        PullToRefresh.init({
-          mainElement: '#header', // above which element?
-          onRefresh(done) {
-            setTimeout(() => {
-              done(); // end pull to refresh
-              //alert('Refreshed');
-            }, 1500);
-          }
-        });
-      }
-    }
-  </script>
-
   <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
     crossorigin="anonymous"></script>
@@ -83,8 +65,6 @@
     integrity="sha256-qk+I9RaF57Ium9VLcn0ZYWjuhbjOXOCCwBl+xnaXa1s=" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script defer type="module" src="./swa.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/pulltorefreshjs@0.1.22/dist/index.umd.min.js"
-    integrity="sha256-F/hso+i1IhzXiDli1f5wrVpTUCXaM2CnPYoXgQgFbKc=" crossorigin="anonymous" onload="p2()""></script>
 </body>
 
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Simple Weather",
   "short_name": "Simple Weather",
   "start_url": "/",
-  "display": "standalone",
+  "display": "browser",
   "description": "A simple webpage to display the local weather forecast from NWS",
   "categories": ["utilities", "weather"],
   "lang": "en",


### PR DESCRIPTION
## Summary by Sourcery

Revert the fullscreen browser feature by removing the custom pull-to-refresh script and changing the display mode from 'standalone' to 'browser' in the manifest to resolve issues on iOS.

Bug Fixes:
- Remove the custom pull-to-refresh functionality for iOS standalone mode due to persistent issues.

Enhancements:
- Change the display mode in the manifest from 'standalone' to 'browser' to address iOS compatibility issues.