### PR TITLE
Revert to pulltojs change.  Not working correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,25 +2,25 @@
 <html lang="en">
 
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Simple Weather App</title>
   <meta name="description" content="Simple Weather App is a javascript web app which queries the US National Weather Service API to provide a
-  responsive weather forecast." />
-  <link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg" />
-  <link rel="shortcut icon" href="/icons/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
-  <meta name="apple-mobile-web-app-title" content="Simple Weather" />
+  responsive weather forecast.">
+  <link rel="icon" type="image/png" href="/icons/favicon-96x96.png" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">
+  <link rel="shortcut icon" href="/icons/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <meta name="apple-mobile-web-app-title" content="Simple Weather">
   <meta property="og:title" content="Simple Weather App">
   <meta property="og:description"
     content="A website which pulls the US NWS weather forecast for your location in a mobile friendly format.">
   <meta property="og:url" content="https://www.partlycloudy.org/">
   <meta property="og:type" content="website">
   <meta name="format-detection" content="telephone=no">
-  <link rel="manifest" href="/icons/site.webmanifest" />
-  <meta name="theme-color" content="#87cefa" media="(prefers-color-scheme: light)" />
-  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
+  <link rel="manifest" href="/icons/site.webmanifest">
+  <meta name="theme-color" content="#87cefa" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
 </head>
 
 <body>

--- a/src/swa.ts
+++ b/src/swa.ts
@@ -11,7 +11,7 @@ import "./scss/main.scss";
 const ptr = PullToRefresh.init({
   mainElement: "body",
   onRefresh() {
-    fetch_weather();
+    globalThis.location.reload();
   },
 });
 
@@ -92,7 +92,7 @@ async function build_header(point: unknown) {
      <div class="container">
        <h1>
          Weather for ${point.properties.relativeLocation.properties.city},
-         ${point.properties.relativeLocation.properties.state} <small><a href="javascript:window.location.reload(true)">(change)</a></small></h1>
+         ${point.properties.relativeLocation.properties.state}</h1>
       </div>
      `;
 }


### PR DESCRIPTION
## Summary by Sourcery

Revert changes to the pull-to-refresh functionality to reload the page instead of fetching weather data, and simplify the UI by removing the '(change)' link from the weather header.

Bug Fixes:
- Revert the pull-to-refresh functionality to reload the page instead of fetching weather data, addressing issues with the previous implementation.

Enhancements:
- Remove the '(change)' link from the weather header to simplify the UI.