### PR TITLE
We don't need the error message twice

### DIFF
--- a/src/routes/Weather/+page.svelte
+++ b/src/routes/Weather/+page.svelte
@@ -209,12 +209,6 @@
 </script>
 
 <div class="container">
-  {#if geolocationError}
-    <div class="error-message" role="alert">
-      {geolocationError}
-    </div>
-  {/if}
-
   <h1 style="text-align: center;">
     {#if geolocationError}
       {geolocationError}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove the duplicate display of the geolocation error message.