### PR TITLE
Remove adapter-auto as it's not needed for cloudflare builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@picocss/pico": "2.0.6",
-        "@sveltejs/adapter-auto": "3.3.1",
         "@sveltejs/adapter-cloudflare": "5.0.1",
         "@sveltejs/kit": "2.16.1",
         "@sveltejs/vite-plugin-svelte": "5.0.3",
@@ -2889,19 +2888,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@sveltejs/adapter-auto": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.3.1.tgz",
-      "integrity": "sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-meta-resolve": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.0.0"
       }
     },
     "node_modules/@sveltejs/adapter-cloudflare": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "@picocss/pico": "2.0.6",
-    "@sveltejs/adapter-auto": "3.3.1",
     "@sveltejs/adapter-cloudflare": "5.0.1",
     "@sveltejs/kit": "2.16.1",
     "@sveltejs/vite-plugin-svelte": "5.0.3",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove the `@sveltejs/adapter-auto` dependency since it is not needed for Cloudflare builds.