### PR TITLE
Add error message for api failure

### DIFF
--- a/src/routes/Weather/+page.svelte
+++ b/src/routes/Weather/+page.svelte
@@ -283,6 +283,8 @@
   <h1 style="text-align: center;">
     {#if geolocationError}
       {geolocationError}
+    {:else if point.hasOwnProperty("detail")}
+      The weather.gov API has returned an error: <br />{point.detail}
     {:else if point.hasOwnProperty("properties")}
       {point.properties.relativeLocation.properties.city}, {point.properties
         .relativeLocation.properties.state}


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Display an informative error message to the user if the weather.gov API returns an error.