### PR TITLE
Remove the limit from the active alerts request as it causes a 400 er…

### DIFF
--- a/src/routes/Weather/+page.svelte
+++ b/src/routes/Weather/+page.svelte
@@ -62,7 +62,7 @@
     point = await point_response.json();
 
     const alerts_response = await fetch(
-      `https://api.weather.gov/alerts/active?status=actual&message_type=alert,update&point=${latitude},${longitude}&limit=50`,
+      `https://api.weather.gov/alerts/active?status=actual&message_type=alert,update&point=${latitude},${longitude}`,
       { headers }
     );
     alerts = await alerts_response.json();


### PR DESCRIPTION
…ror and the page fails to load.

## Summary by Sourcery

Bug Fixes:
- Remove the `limit=50` parameter from the active alerts request to fix 400 errors when fetching alerts.