### PR TITLE
Switch alert headline to type of alert.

### DIFF
--- a/src/routes/Weather/+page.svelte
+++ b/src/routes/Weather/+page.svelte
@@ -411,8 +411,12 @@
       {#each alerts.features as alert}
         <details>
           <!-- svelte-ignore a11y_no_redundant_roles -->
-          <summary role="button" class={alert.properties.severity}>
-            {alert.properties.parameters.NWSheadline}</summary
+          <summary
+            role="button"
+            style="text-align: center;"
+            class={alert.properties.severity}
+          >
+            {alert.properties.event}</summary
           >
           <p>{alert.properties.description}</p>
           <p>{alert.properties.instruction}</p>


### PR DESCRIPTION
This deals with "missing" NWSHeadlines.

## Summary by Sourcery

Update weather alert summaries to use the alert’s event type instead of the NWS headline and center-align the summary text

Enhancements:
- Switch alert headline source from parameters.NWSheadline to properties.event to handle missing headlines
- Add center-aligned styling to the alert summary