### PR TITLE
Correct the if to include the weather AND apparent temp if there is a…

### DIFF
--- a/src/routes/Weather/+page.svelte
+++ b/src/routes/Weather/+page.svelte
@@ -340,17 +340,14 @@
   <div id="currently">
     {#if forecastHourly.hasOwnProperty("properties") && forecastHourly.properties.periods && forecastHourly.properties.periods[0]?.appTemp}
       <h4 style="text-align: center;">
+        {forecastHourly.properties.periods[0].shortForecast}, {forecastHourly
+          .properties.periods[0].temperature}
+        {forecastHourly.properties.periods[0].temperatureUnit}
         <!-- If Temp and Feels like are the same, don't print Feels like -->
         {#if forecastHourly.properties.periods[0].temperature != Math.round(forecastHourly.properties.periods[0].appTemp)}
-          {forecastHourly.properties.periods[0].shortForecast}, {forecastHourly
-            .properties.periods[0].temperature}
-          {forecastHourly.properties.periods[0].temperatureUnit}, Feels Like: {Math.round(
+          <br />Feels Like: {Math.round(
             forecastHourly.properties.periods[0].appTemp
           )}
-          {forecastHourly.properties.periods[0].temperatureUnit}
-        {:else}
-          {forecastHourly.properties.periods[0].shortForecast}, {forecastHourly
-            .properties.periods[0].temperature}
           {forecastHourly.properties.periods[0].temperatureUnit}
         {/if}
       </h4>

--- a/src/routes/Weather/+page.svelte
+++ b/src/routes/Weather/+page.svelte
@@ -342,7 +342,9 @@
       <h4 style="text-align: center;">
         <!-- If Temp and Feels like are the same, don't print Feels like -->
         {#if forecastHourly.properties.periods[0].temperature != Math.round(forecastHourly.properties.periods[0].appTemp)}
-          , Feels Like: {Math.round(
+          {forecastHourly.properties.periods[0].shortForecast}, {forecastHourly
+            .properties.periods[0].temperature}
+          {forecastHourly.properties.periods[0].temperatureUnit}, Feels Like: {Math.round(
             forecastHourly.properties.periods[0].appTemp
           )}
           {forecastHourly.properties.periods[0].temperatureUnit}


### PR DESCRIPTION
…n apparent temp.  Was just showing the apparent temp.

## Summary by Sourcery

Bug Fixes:
- Fix display logic to include short forecast, actual temperature, and unit in addition to feels-like temperature